### PR TITLE
Updated the OpenSSL license in the library documentation

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -1,20 +1,20 @@
 ## OpenSSL
 
-The OpenSSL toolkit stays under a dual license, i.e. both the conditions of the OpenSSL License and the original SSLeay license apply to the toolkit. See below for the actual license texts. Actually both licenses are BSD-style Open Source licenses. In case of any license issues related to OpenSSL please contact openssl-core@openssl.org.
-
-```
-  OpenSSL License
-  ---------------
+The OpenSSL toolkit stays under a double license, i.e. both the conditions of the OpenSSL License and the original SSLeay license apply to the toolkit. See below for the actual license texts.
   
+```
+OpenSSL License
+---------------
+
 /* ====================================================================
- * Copyright (c) 1998-2016 The OpenSSL Project.  All rights reserved.
+ * Copyright (c) 1998-2019 The OpenSSL Project.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
  *
  * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer. 
+ *    notice, this list of conditions and the following disclaimer.
  *
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in
@@ -69,21 +69,21 @@ The OpenSSL toolkit stays under a dual license, i.e. both the conditions of the 
  * This package is an SSL implementation written
  * by Eric Young (eay@cryptsoft.com).
  * The implementation was written so as to conform with Netscapes SSL.
- * 
+ *
  * This library is free for commercial and non-commercial use as long as
  * the following conditions are aheared to.  The following conditions
  * apply to all code found in this distribution, be it the RC4, RSA,
  * lhash, DES, etc., code; not just the SSL code.  The SSL documentation
  * included with this distribution is covered by the same copyright terms
  * except that the holder is Tim Hudson (tjh@cryptsoft.com).
- * 
+ *
  * Copyright remains Eric Young's, and as such any Copyright notices in
  * the code are not to be removed.
  * If this package is used in a product, Eric Young should be given attribution
  * as the author of the parts of the library used.
  * This can be in the form of a textual message at program startup or
  * in documentation (online or textual) provided with the package.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
@@ -98,10 +98,10 @@ The OpenSSL toolkit stays under a dual license, i.e. both the conditions of the 
  *     Eric Young (eay@cryptsoft.com)"
  *    The word 'cryptographic' can be left out if the rouines from the library
  *    being used are not cryptographic related :-).
- * 4. If you include any Windows specific code (or a derivative thereof) from 
+ * 4. If you include any Windows specific code (or a derivative thereof) from
  *    the apps directory (application code) you must include an acknowledgement:
  *    "This product includes software written by Tim Hudson (tjh@cryptsoft.com)"
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY ERIC YOUNG ``AS IS'' AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -113,10 +113,10 @@ The OpenSSL toolkit stays under a dual license, i.e. both the conditions of the 
  * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
- * 
+ *
  * The licence and distribution terms for any publically available version or
  * derivative of this code cannot be changed.  i.e. this code cannot simply be
  * copied and put under another distribution licence
  * [including the GNU Public Licence.]
  */
- ```
+```

--- a/third_party.md
+++ b/third_party.md
@@ -33,10 +33,3 @@ The third party software included and used by this project is:
 * Copyright (c) 1995-1998 Eric A. Young, Tim J. Hudson
 * Licensed under a dual-license (the OpenSSL license plus the SSLeay license)
 * See https://github.com/openssl/openssl/tree/OpenSSL_1_1_1-stable
-
-**cpp-base64.**
-
-* Copyright © 2004-2017 by René Nyffenegger
-* Licensed under zlib License.
-* See https://github.com/ReneNyffenegger/cpp-base64.
-

--- a/third_party.md
+++ b/third_party.md
@@ -27,11 +27,12 @@ original licenses.
 
 The third party software included and used by this project is:
 
-**OpenSSL 1.0.2**
+**OpenSSL 1.1.1**
 
-* Copyright (c) 1998-2016 The OpenSSL Project.  All rights reserved.
-* Licensed under OpenSSL License.
-* See https://github.com/openssl/openssl/treeOpenSSL_1_0_2f.
+* Copyright (c) 1998-2019 The OpenSSL Project
+* Copyright (c) 1995-1998 Eric A. Young, Tim J. Hudson
+* Licensed under a dual-license (the OpenSSL license plus the SSLeay license)
+* See https://github.com/openssl/openssl/tree/OpenSSL_1_1_1-stable
 
 **cpp-base64.**
 


### PR DESCRIPTION
Fixes #34 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Only documentation changes made.

### Summary
1. The OpenSSL dependency was updated in PR #19 to v1.1.1. References to the OpenSSL dependency were updated to match the license included in v1.1.1.
    1. The OpenSSL license was updated in DEPENDENCIES.md
    1. The OpenSSL version and copyright was updated in third_party.md
1. The reference to the not used **cpp-base64.** library was removed in third_party.md

### Changelog
##### Enhancements
* Updated the OpenSSL license in the library documentation

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
