### PR TITLE
Use the SDL policy server data as a model for parsing URL response 

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ Depending on the response you return for the certificate request, you may need t
 ```
 {
   "meta": {
-  "request_id": "...",
+    "request_id": "<The id of your request>",
     "code": 200,
     "message": null
   },
   "data": {
-    "certificate": "..."
+    "certificate": "<The base64 encoded PFX file data>"
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The following customizations must be made by the OEM in order for the library to
 ### Certificate URL
 The `CertQAURL` URL in the **SDLPrivateSecurityConstants.m** file should be updated to point to a database that will return certificate data for a specific SDL `appID`. The certificate data will be stored on disk as a `.pfx` file so it can persist between app sessions. If the certificate has expired, the library will automatically try to download a new certificate. 
 
-Depending on the what you return for the certificate request, you may have to update how the certificate is extracted from the JSON object in **_SDLCertificateManager.m**. Currently the certificate manager is setup to handle parsing this JSON format:
+Depending on the response you return for the certificate request, you may need to update how the certificate is extracted from the JSON object in **_SDLCertificateManager.m**. Currently the certificate manager is set up to handle parsing this JSON format:
 ```
 {
   "meta": {

--- a/README.md
+++ b/README.md
@@ -15,7 +15,19 @@ The following customizations must be made by the OEM in order for the library to
 ### Certificate URL
 The `CertQAURL` URL in the **SDLPrivateSecurityConstants.m** file should be updated to point to a database that will return certificate data for a specific SDL `appID`. The certificate data will be stored on disk as a `.pfx` file so it can persist between app sessions. If the certificate has expired, the library will automatically try to download a new certificate. 
 
-Depending on the what you return for the certificate request, you may have to update how the certificate is extracted from the JSON object in **_SDLCertificateManager.m**.
+Depending on the what you return for the certificate request, you may have to update how the certificate is extracted from the JSON object in **_SDLCertificateManager.m**. Currently the certificate manager is setup to handle parsing this JSON format:
+```
+{
+  "meta": {
+  "request_id": "...",
+    "code": 200,
+    "message": null
+  },
+  "data": {
+    "certificate": "..."
+  }
+}
+```
 
 ### Vehicle Makes
 The `availableMakes` property should be updated in the **SDLSecurityManager.m** file to list all supported vehicle types. The `vehicleType` returned by SDL Core's `RegisterAppInterface` response is used to select the security manager associated with that vehicle type. It is important that the vehicle types listed in `availableMakes` match exactly the `vehicleType`s returned by the `RegisterAppInterface` response, otherwise the security manager will not be selected and configured. 

--- a/SDLSecurity/_SDLCertificateManager.m
+++ b/SDLSecurity/_SDLCertificateManager.m
@@ -91,7 +91,7 @@
 - (void)retrieveNewCertificateWithAppId:(NSString *)appId completionHandler:(SDLCertificateRetrievedHandler)completionHandler {
     SDLSecurityLogD(@"Performing network request for a certificate");
 
-    NSArray<NSURLQueryItem *> *queryItems = @[[[NSURLQueryItem alloc] initWithName:@"appID" value:appId]];
+    NSArray<NSURLQueryItem *> *queryItems = @[[[NSURLQueryItem alloc] initWithName:@"appId" value:appId]];
     NSURLComponents *queryComponents = [NSURLComponents componentsWithString:self.certificateURL];
     queryComponents.queryItems = queryItems;
     NSURL *url = queryComponents.URL;
@@ -109,15 +109,14 @@
         }
 
         NSError *jsonError = nil;
-        NSArray *jsonArray = [NSJSONSerialization JSONObjectWithData:data options:0 error:&jsonError];
-        NSDictionary *jsonDictionary = jsonArray.firstObject;
+        NSDictionary *jsonDictionary = [NSJSONSerialization JSONObjectWithData:data options:0 error:&jsonError];
 
         if (jsonError != nil || jsonDictionary == nil) {
             SDLSecurityLogE(@"Error parsing network request data");
             return completionHandler(NO, [NSError errorWithDomain:SDLSecurityErrorDomain code:SDLTLSErrorCodeNoCertificate userInfo:@{NSLocalizedDescriptionKey: @"Network request did not return a certificate"}]);
         }
 
-        NSData *certificateData = [[NSData alloc] initWithBase64EncodedData:[jsonDictionary objectForKey:@"certificate"] options:0];
+        NSData *certificateData = [[NSData alloc] initWithBase64EncodedData:[jsonDictionary valueForKeyPath:@"data.certificate"] options:0];
         if (certificateData.length == 0) {
             SDLSecurityLogE(@"Certificate is invalid");
             return completionHandler(NO, [NSError errorWithDomain:SDLSecurityErrorDomain code:SDLTLSErrorCodeCertificateInvalid userInfo:@{NSLocalizedDescriptionKey: @"Certificate is invalid"}]);


### PR DESCRIPTION
Fixes #36, #23, #28 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Smoke tested with the SDL policy server.

### Summary
* Updated the certificate manager to parse the JSON formatted response from the SDL Policy Server.
* Added information about the expected JSON response to the README

### Changelog
##### Enhancements
*  The certificate manager now parses a JSON formatted response from the SDL Policy Server.

### Tasks Remaining:
- [x] Test with sdl_core with certificates for both sdl_core and mobile downloaded from the policy server

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
