### PR TITLE
Consolidate private constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The following customizations must be made by the OEM in order for the library to
 ### Certificate URL
 The `CertQAURL` URL in the **SDLPrivateSecurityConstants.m** file should be updated to point to a database that will return certificate data for a specific SDL `appID`. The certificate data will be stored on disk as a `.pfx` file so it can persist between app sessions. If the certificate has expired, the library will automatically try to download a new certificate. 
 
-Depending on the response you return for the certificate request, you may need to update how the certificate is extracted from the JSON object in **_SDLCertificateManager.m**. Currently the certificate manager is set up to handle parsing this JSON format:
+Depending on the response you return for the certificate request, you may need to update how the certificate is extracted from the JSON object in **SDLCertificateManager.m**. Currently the certificate manager is set up to handle parsing this JSON format:
 ```
 {
   "meta": {
@@ -30,7 +30,7 @@ Depending on the response you return for the certificate request, you may need t
 ```
 
 ### Vehicle Makes
-The `availableMakes` property should be updated in the **SDLSecurityManager.m** file to list all supported vehicle types. The `vehicleType` returned by SDL Core's `RegisterAppInterface` response is used to select the security manager associated with that vehicle type. It is important that the vehicle types listed in `availableMakes` match exactly the `vehicleType`s returned by the `RegisterAppInterface` response, otherwise the security manager will not be selected and configured. 
+The `availableMakes` property should be updated in the **SDLPrivateSecurityConstants.m** file to list all supported vehicle types. The `vehicleType` returned by SDL Core's `RegisterAppInterface` response is used to select the security manager associated with that vehicle type. It is important that the vehicle types listed in `availableMakes` match exactly the `vehicleType`s returned by the `RegisterAppInterface` response, otherwise the security manager will not be selected and configured. 
 
 ### Checking Certificate Parameters
 In order to check the mobile certificate parameters, the security library needs the TLS issuer and certificate password used to generate the certificate. Currently the the `SDLTLSIssuer` and `SDLTLSCertPassword` properties used to check the certificate are hardcoded in the **SDLPrivateSecurityConstants.m** file. 

--- a/SDLSecurity.xcodeproj/project.pbxproj
+++ b/SDLSecurity.xcodeproj/project.pbxproj
@@ -13,9 +13,9 @@
 		5D40CA9A1C51215200E6F987 /* SDLSecurityManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D40CA981C51215200E6F987 /* SDLSecurityManager.m */; };
 		5D4DC2E123214D00003A69B0 /* SDLSecurityLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D4DC2DF23214D00003A69B0 /* SDLSecurityLogger.h */; };
 		5D4DC2E223214D00003A69B0 /* SDLSecurityLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D4DC2E023214D00003A69B0 /* SDLSecurityLogger.m */; };
-		5D5E27871C848A1900495F0B /* _SDLCertificateManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D5E27851C848A1900495F0B /* _SDLCertificateManager.h */; };
-		5D5E27881C848A1900495F0B /* _SDLCertificateManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D5E27861C848A1900495F0B /* _SDLCertificateManager.m */; };
-		5D5E27891C848A1D00495F0B /* _SDLCertificateManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D5E27861C848A1900495F0B /* _SDLCertificateManager.m */; };
+		5D5E27871C848A1900495F0B /* SDLCertificateManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D5E27851C848A1900495F0B /* SDLCertificateManager.h */; };
+		5D5E27881C848A1900495F0B /* SDLCertificateManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D5E27861C848A1900495F0B /* SDLCertificateManager.m */; };
+		5D5E27891C848A1D00495F0B /* SDLCertificateManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D5E27861C848A1900495F0B /* SDLCertificateManager.m */; };
 		5D8415F91C7E2F75002DC330 /* SDLTLSEngineTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D8415F81C7E2F75002DC330 /* SDLTLSEngineTests.m */; };
 		5D8468271C84E2E100592787 /* SDLCertificateManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D8468261C84E2E100592787 /* SDLCertificateManagerTests.m */; };
 		5D84682D1C86256D00592787 /* SDLPrivateSecurityConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D84682B1C86256D00592787 /* SDLPrivateSecurityConstants.h */; };
@@ -28,10 +28,10 @@
 		5DF04F361C629116001B9986 /* SDLSecurityType.h in Headers */ = {isa = PBXBuildFile; fileRef = 5DC412F31C62426F0062E6F9 /* SDLSecurityType.h */; };
 		5DF916FB1C5A6C69009C7B55 /* SDLSecurityManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D40CA981C51215200E6F987 /* SDLSecurityManager.m */; };
 		5DF916FF1C5A6C94009C7B55 /* SDLSecurityManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D40CA971C51215200E6F987 /* SDLSecurityManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5DF917091C5A6F1C009C7B55 /* _SDLTLSEngine.h in Headers */ = {isa = PBXBuildFile; fileRef = 5DF917071C5A6F1C009C7B55 /* _SDLTLSEngine.h */; };
-		5DF9170A1C5A6F1C009C7B55 /* _SDLTLSEngine.h in Headers */ = {isa = PBXBuildFile; fileRef = 5DF917071C5A6F1C009C7B55 /* _SDLTLSEngine.h */; };
-		5DF9170B1C5A6F1C009C7B55 /* _SDLTLSEngine.m in Sources */ = {isa = PBXBuildFile; fileRef = 5DF917081C5A6F1C009C7B55 /* _SDLTLSEngine.m */; };
-		5DF9170C1C5A6F1C009C7B55 /* _SDLTLSEngine.m in Sources */ = {isa = PBXBuildFile; fileRef = 5DF917081C5A6F1C009C7B55 /* _SDLTLSEngine.m */; };
+		5DF917091C5A6F1C009C7B55 /* SDLTLSEngine.h in Headers */ = {isa = PBXBuildFile; fileRef = 5DF917071C5A6F1C009C7B55 /* SDLTLSEngine.h */; };
+		5DF9170A1C5A6F1C009C7B55 /* SDLTLSEngine.h in Headers */ = {isa = PBXBuildFile; fileRef = 5DF917071C5A6F1C009C7B55 /* SDLTLSEngine.h */; };
+		5DF9170B1C5A6F1C009C7B55 /* SDLTLSEngine.m in Sources */ = {isa = PBXBuildFile; fileRef = 5DF917081C5A6F1C009C7B55 /* SDLTLSEngine.m */; };
+		5DF9170C1C5A6F1C009C7B55 /* SDLTLSEngine.m in Sources */ = {isa = PBXBuildFile; fileRef = 5DF917081C5A6F1C009C7B55 /* SDLTLSEngine.m */; };
 		5DF917121C5AA368009C7B55 /* SDLSecurityConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 5DF917101C5AA368009C7B55 /* SDLSecurityConstants.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5DF917131C5AA368009C7B55 /* SDLSecurityConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 5DF917101C5AA368009C7B55 /* SDLSecurityConstants.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5DF917141C5AA368009C7B55 /* SDLSecurityConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 5DF917111C5AA368009C7B55 /* SDLSecurityConstants.m */; };
@@ -78,16 +78,16 @@
 		5D4DC2DF23214D00003A69B0 /* SDLSecurityLogger.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SDLSecurityLogger.h; sourceTree = "<group>"; };
 		5D4DC2E023214D00003A69B0 /* SDLSecurityLogger.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDLSecurityLogger.m; sourceTree = "<group>"; };
 		5D4DC2E323215AA8003A69B0 /* SDLSecurityLoggerMacros.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SDLSecurityLoggerMacros.h; sourceTree = "<group>"; };
-		5D5E27851C848A1900495F0B /* _SDLCertificateManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _SDLCertificateManager.h; sourceTree = "<group>"; };
-		5D5E27861C848A1900495F0B /* _SDLCertificateManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = _SDLCertificateManager.m; sourceTree = "<group>"; };
+		5D5E27851C848A1900495F0B /* SDLCertificateManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDLCertificateManager.h; sourceTree = "<group>"; };
+		5D5E27861C848A1900495F0B /* SDLCertificateManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDLCertificateManager.m; sourceTree = "<group>"; };
 		5D8415F81C7E2F75002DC330 /* SDLTLSEngineTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDLTLSEngineTests.m; sourceTree = "<group>"; };
 		5D8468261C84E2E100592787 /* SDLCertificateManagerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDLCertificateManagerTests.m; sourceTree = "<group>"; };
 		5D84682B1C86256D00592787 /* SDLPrivateSecurityConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDLPrivateSecurityConstants.h; sourceTree = "<group>"; };
 		5D84682C1C86256D00592787 /* SDLPrivateSecurityConstants.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDLPrivateSecurityConstants.m; sourceTree = "<group>"; };
 		5DC412F31C62426F0062E6F9 /* SDLSecurityType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDLSecurityType.h; sourceTree = "<group>"; };
 		5DF916F21C5A6C2B009C7B55 /* libSDLSecurityStatic.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libSDLSecurityStatic.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		5DF917071C5A6F1C009C7B55 /* _SDLTLSEngine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _SDLTLSEngine.h; sourceTree = "<group>"; };
-		5DF917081C5A6F1C009C7B55 /* _SDLTLSEngine.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = _SDLTLSEngine.m; sourceTree = "<group>"; };
+		5DF917071C5A6F1C009C7B55 /* SDLTLSEngine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDLTLSEngine.h; sourceTree = "<group>"; };
+		5DF917081C5A6F1C009C7B55 /* SDLTLSEngine.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDLTLSEngine.m; sourceTree = "<group>"; };
 		5DF917101C5AA368009C7B55 /* SDLSecurityConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDLSecurityConstants.h; sourceTree = "<group>"; };
 		5DF917111C5AA368009C7B55 /* SDLSecurityConstants.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDLSecurityConstants.m; sourceTree = "<group>"; };
 		8842509C230D9C0000F83FD7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -324,10 +324,10 @@
 				5D84682B1C86256D00592787 /* SDLPrivateSecurityConstants.h */,
 				5D84682C1C86256D00592787 /* SDLPrivateSecurityConstants.m */,
 				5DC412F31C62426F0062E6F9 /* SDLSecurityType.h */,
-				5DF917071C5A6F1C009C7B55 /* _SDLTLSEngine.h */,
-				5DF917081C5A6F1C009C7B55 /* _SDLTLSEngine.m */,
-				5D5E27851C848A1900495F0B /* _SDLCertificateManager.h */,
-				5D5E27861C848A1900495F0B /* _SDLCertificateManager.m */,
+				5DF917071C5A6F1C009C7B55 /* SDLTLSEngine.h */,
+				5DF917081C5A6F1C009C7B55 /* SDLTLSEngine.m */,
+				5D5E27851C848A1900495F0B /* SDLCertificateManager.h */,
+				5D5E27861C848A1900495F0B /* SDLCertificateManager.m */,
 			);
 			name = Private;
 			sourceTree = "<group>";
@@ -527,12 +527,12 @@
 			files = (
 				5DF917121C5AA368009C7B55 /* SDLSecurityConstants.h in Headers */,
 				5D40CA991C51215200E6F987 /* SDLSecurityManager.h in Headers */,
-				5DF917091C5A6F1C009C7B55 /* _SDLTLSEngine.h in Headers */,
+				5DF917091C5A6F1C009C7B55 /* SDLTLSEngine.h in Headers */,
 				5D40CA811C511C7200E6F987 /* SDLSecurity.h in Headers */,
 				5D4DC2E123214D00003A69B0 /* SDLSecurityLogger.h in Headers */,
 				5D84682D1C86256D00592787 /* SDLPrivateSecurityConstants.h in Headers */,
 				5DC412F41C62426F0062E6F9 /* SDLSecurityType.h in Headers */,
-				5D5E27871C848A1900495F0B /* _SDLCertificateManager.h in Headers */,
+				5D5E27871C848A1900495F0B /* SDLCertificateManager.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -543,7 +543,7 @@
 				5DF04F361C629116001B9986 /* SDLSecurityType.h in Headers */,
 				5D84682E1C86256D00592787 /* SDLPrivateSecurityConstants.h in Headers */,
 				5DAECE79232BF3890041A7E9 /* SDLSecurityLogger.h in Headers */,
-				5DF9170A1C5A6F1C009C7B55 /* _SDLTLSEngine.h in Headers */,
+				5DF9170A1C5A6F1C009C7B55 /* SDLTLSEngine.h in Headers */,
 				5DF917131C5AA368009C7B55 /* SDLSecurityConstants.h in Headers */,
 				5DF916FF1C5A6C94009C7B55 /* SDLSecurityManager.h in Headers */,
 			);
@@ -687,10 +687,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5D5E27881C848A1900495F0B /* _SDLCertificateManager.m in Sources */,
+				5D5E27881C848A1900495F0B /* SDLCertificateManager.m in Sources */,
 				5D40CA9A1C51215200E6F987 /* SDLSecurityManager.m in Sources */,
 				8897ED0223353CED00C1F4A3 /* missing_openSSL_functions.m in Sources */,
-				5DF9170B1C5A6F1C009C7B55 /* _SDLTLSEngine.m in Sources */,
+				5DF9170B1C5A6F1C009C7B55 /* SDLTLSEngine.m in Sources */,
 				5DF917141C5AA368009C7B55 /* SDLSecurityConstants.m in Sources */,
 				5D84682F1C86256D00592787 /* SDLPrivateSecurityConstants.m in Sources */,
 				5D4DC2E223214D00003A69B0 /* SDLSecurityLogger.m in Sources */,
@@ -710,10 +710,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5D5E27891C848A1D00495F0B /* _SDLCertificateManager.m in Sources */,
+				5D5E27891C848A1D00495F0B /* SDLCertificateManager.m in Sources */,
 				5DF916FB1C5A6C69009C7B55 /* SDLSecurityManager.m in Sources */,
 				8897ED0323353CED00C1F4A3 /* missing_openSSL_functions.m in Sources */,
-				5DF9170C1C5A6F1C009C7B55 /* _SDLTLSEngine.m in Sources */,
+				5DF9170C1C5A6F1C009C7B55 /* SDLTLSEngine.m in Sources */,
 				5DF917151C5AA368009C7B55 /* SDLSecurityConstants.m in Sources */,
 				5D8468301C86256D00592787 /* SDLPrivateSecurityConstants.m in Sources */,
 				5DAECE7A232BF38C0041A7E9 /* SDLSecurityLogger.m in Sources */,

--- a/SDLSecurity.xcodeproj/project.pbxproj
+++ b/SDLSecurity.xcodeproj/project.pbxproj
@@ -912,7 +912,7 @@
 				);
 				INFOPLIST_FILE = SDLSecurityTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				ONLY_ACTIVE_ARCH = NO;
+				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.livio.SDLSecurityTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -928,7 +928,7 @@
 				);
 				INFOPLIST_FILE = SDLSecurityTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				ONLY_ACTIVE_ARCH = NO;
+				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.livio.SDLSecurityTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};

--- a/SDLSecurity/SDLCertificateManager.h
+++ b/SDLSecurity/SDLCertificateManager.h
@@ -1,5 +1,5 @@
 //
-//  _SDLCertificateManager.h
+//  SDLCertificateManager.h
 //  SDLSecurity
 //
 //  Created by Joel Fischer on 2/29/16.
@@ -18,9 +18,7 @@ typedef void (^SDLCertificateRetrievedHandler)(BOOL success, NSError *__nullable
 @property (nonatomic, copy, readonly, nullable) NSData *certificateData;
 
 - (instancetype)init NS_UNAVAILABLE;
-
 - (instancetype)initWithCertificateServerURL:(NSString *)url;
-
 - (void)retrieveNewCertificateWithAppId:(NSString *)appId completionHandler:(SDLCertificateRetrievedHandler)completionHandler;
 
 @end

--- a/SDLSecurity/SDLCertificateManager.h
+++ b/SDLSecurity/SDLCertificateManager.h
@@ -13,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 typedef void (^SDLCertificateRetrievedHandler)(BOOL success, NSError *__nullable error);
 
 
-@interface _SDLCertificateManager : NSObject
+@interface SDLCertificateManager : NSObject
 
 @property (nonatomic, copy, readonly, nullable) NSData *certificateData;
 

--- a/SDLSecurity/SDLCertificateManager.m
+++ b/SDLSecurity/SDLCertificateManager.m
@@ -1,5 +1,5 @@
 //
-//  _SDLCertificateManager.m
+//  SDLCertificateManager.m
 //  SDLSecurity
 //
 //  Created by Joel Fischer on 2/29/16.

--- a/SDLSecurity/SDLCertificateManager.m
+++ b/SDLSecurity/SDLCertificateManager.m
@@ -6,21 +6,21 @@
 //  Copyright © 2016 livio. All rights reserved.
 //
 
-#import "_SDLCertificateManager.h"
+#import "SDLCertificateManager.h"
 
 #import "SDLPrivateSecurityConstants.h"
 #import "SDLSecurityConstants.h"
 #import "SDLSecurityLoggerMacros.h"
 
 
-@interface _SDLCertificateManager ()
+@interface SDLCertificateManager ()
 
 @property (nonatomic, copy) NSString *certificateURL;
 
 @end
 
 
-@implementation _SDLCertificateManager
+@implementation SDLCertificateManager
 
 - (instancetype)initWithCertificateServerURL:(NSString *)url {
     self = [super init];

--- a/SDLSecurity/SDLPrivateSecurityConstants.h
+++ b/SDLSecurity/SDLPrivateSecurityConstants.h
@@ -8,7 +8,6 @@
 
 #import <Foundation/Foundation.h>
 
-extern NSSet<NSString *> *availableMakes;
 extern NSString *const CertDevURL;
 extern NSString *const CertQAURL;
 extern NSString *const CertProdURL;
@@ -17,5 +16,7 @@ extern NSString *const SDLTLSIssuer;
 extern const char *SDLTLSCertPassword;
 
 @interface SDLPrivateSecurityConstants : NSObject
+
++ (NSSet<NSString *> *)availableMakes;
 
 @end

--- a/SDLSecurity/SDLPrivateSecurityConstants.h
+++ b/SDLSecurity/SDLPrivateSecurityConstants.h
@@ -8,11 +8,14 @@
 
 #import <Foundation/Foundation.h>
 
-
+extern NSSet<NSString *> *availableMakes;
 extern NSString *const CertDevURL;
 extern NSString *const CertQAURL;
 extern NSString *const CertProdURL;
 extern NSString *const VendorName;
-
 extern NSString *const SDLTLSIssuer;
 extern const char *SDLTLSCertPassword;
+
+@interface SDLPrivateSecurityConstants : NSObject
+
+@end

--- a/SDLSecurity/SDLPrivateSecurityConstants.m
+++ b/SDLSecurity/SDLPrivateSecurityConstants.m
@@ -8,11 +8,18 @@
 
 #import "SDLPrivateSecurityConstants.h"
 
-
+NSSet<NSString *> *availableMakes;
 NSString *const CertDevURL = @"http://www.google.com";
 NSString *const CertQAURL = @"http://www.google.com";
 NSString *const CertProdURL = @"http://www.google.com";
-NSString *const VendorName = @"SDL"; // Change
+NSString *const VendorName = @"SDL";
+NSString *const SDLTLSIssuer = @"SDLTLSIssuer";
+const char *SDLTLSCertPassword = "SDLTLSCertPassword";
 
-NSString *const SDLTLSIssuer = @"YourIssuer";
-const char *SDLTLSCertPassword = "CertPassword";
+@implementation SDLPrivateSecurityConstants
+
++ (NSSet<NSString *> *)availableMakes {
+    return [NSSet setWithArray:@[@"SDL"]];
+}
+
+@end

--- a/SDLSecurity/SDLPrivateSecurityConstants.m
+++ b/SDLSecurity/SDLPrivateSecurityConstants.m
@@ -8,7 +8,6 @@
 
 #import "SDLPrivateSecurityConstants.h"
 
-NSSet<NSString *> *availableMakes;
 NSString *const CertDevURL = @"http://www.google.com";
 NSString *const CertQAURL = @"http://www.google.com";
 NSString *const CertProdURL = @"http://www.google.com";

--- a/SDLSecurity/SDLSecurityManager.m
+++ b/SDLSecurity/SDLSecurityManager.m
@@ -89,7 +89,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 + (NSSet<NSString *> *)availableMakes {
-    return [SDLPrivateSecurityConstants.class availableMakes];
+    return SDLPrivateSecurityConstants.availableMakes;
 }
 
 @end

--- a/SDLSecurity/SDLSecurityManager.m
+++ b/SDLSecurity/SDLSecurityManager.m
@@ -8,8 +8,9 @@
 
 #import "SDLSecurityManager.h"
 
-#import "_SDLCertificateManager.h"
-#import "_SDLTLSEngine.h"
+#import "SDLCertificateManager.h"
+#import "SDLTLSEngine.h"
+#import "SDLPrivateSecurityConstants.h"
 #import "SDLSecurityConstants.h"
 
 typedef NS_ENUM(NSUInteger, SDLTLSState) {
@@ -23,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SDLSecurityManager () {
     @private
-    _SDLTLSEngine *_privateSecurity;
+    SDLTLSEngine *_privateSecurity;
 }
 
 @property (assign, nonatomic) SDLTLSState state;
@@ -54,7 +55,7 @@ NS_ASSUME_NONNULL_BEGIN
     }
     
     // Set up the TLS engine
-    _privateSecurity = [[_SDLTLSEngine alloc] initWithAppId:appId];
+    _privateSecurity = [[SDLTLSEngine alloc] initWithAppId:appId];
     [_privateSecurity initializeTLSWithCompletionHandler:^(BOOL success, NSError * _Nullable error) {
         if (success) {
             self.state = SDLTLSStateInitialized;
@@ -88,7 +89,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 + (NSSet<NSString *> *)availableMakes {
-    return [NSSet setWithArray:@[@"Example"]];
+    return availableMakes;
 }
 
 @end

--- a/SDLSecurity/SDLSecurityManager.m
+++ b/SDLSecurity/SDLSecurityManager.m
@@ -89,7 +89,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 + (NSSet<NSString *> *)availableMakes {
-    return availableMakes;
+    return [SDLPrivateSecurityConstants.class availableMakes];
 }
 
 @end

--- a/SDLSecurity/SDLSecurityManager.m
+++ b/SDLSecurity/SDLSecurityManager.m
@@ -9,9 +9,9 @@
 #import "SDLSecurityManager.h"
 
 #import "SDLCertificateManager.h"
-#import "SDLTLSEngine.h"
 #import "SDLPrivateSecurityConstants.h"
 #import "SDLSecurityConstants.h"
+#import "SDLTLSEngine.h"
 
 typedef NS_ENUM(NSUInteger, SDLTLSState) {
     SDLTLSStateUninitialized,

--- a/SDLSecurity/SDLTLSEngine.h
+++ b/SDLSecurity/SDLTLSEngine.h
@@ -10,7 +10,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface _SDLTLSEngine : NSObject
+@interface SDLTLSEngine : NSObject
 
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/SDLSecurity/SDLTLSEngine.h
+++ b/SDLSecurity/SDLTLSEngine.h
@@ -1,5 +1,5 @@
 //
-//  SDLSecurityPrivate.h
+//  SDLTLSEngine.h
 //  SDLSecurity
 //
 //  Created by Joel Fischer on 1/28/16.

--- a/SDLSecurity/SDLTLSEngine.m
+++ b/SDLSecurity/SDLTLSEngine.m
@@ -6,7 +6,7 @@
 //  Copyright © 2016 livio. All rights reserved.
 //
 
-#import "_SDLTLSEngine.h"
+#import "SDLTLSEngine.h"
 
 #import <openssl/bio.h>
 #import <openssl/ssl.h>
@@ -29,7 +29,7 @@ typedef NS_ENUM(NSUInteger, SDLTLSEngineState) {
 
 static const int SDLTLSReadBufferSize = 4096;
 
-@interface _SDLTLSEngine () {
+@interface SDLTLSEngine () {
     SSL *sslConnection;
     SSL_CTX *sslContext;
     BIO *readBIO;
@@ -43,7 +43,7 @@ static const int SDLTLSReadBufferSize = 4096;
 @end
 
 
-@implementation _SDLTLSEngine
+@implementation SDLTLSEngine
 
 #pragma mark - Lifecycle
 

--- a/SDLSecurity/SDLTLSEngine.m
+++ b/SDLSecurity/SDLTLSEngine.m
@@ -1,5 +1,5 @@
 //
-//  SDLSecurityPrivate.m
+//  SDLTLSEngine.m
 //  SDLSecurity
 //
 //  Created by Joel Fischer on 1/28/16.
@@ -14,7 +14,7 @@
 #import <openssl/conf.h>
 #import <openssl/pkcs12.h>
 
-#import "_SDLCertificateManager.h"
+#import "SDLCertificateManager.h"
 #import "SDLPrivateSecurityConstants.h"
 #import "SDLSecurityConstants.h"
 #import "SDLSecurityLoggerMacros.h"
@@ -37,7 +37,7 @@ static const int SDLTLSReadBufferSize = 4096;
 }
 
 @property (assign, nonatomic) SDLTLSEngineState state;
-@property (strong, nonatomic) _SDLCertificateManager *certificateManager;
+@property (strong, nonatomic) SDLCertificateManager *certificateManager;
 @property (copy, nonatomic) NSString *appId;
 
 @end
@@ -59,7 +59,7 @@ static const int SDLTLSReadBufferSize = 4096;
     
     _state = SDLTLSEngineStateDisconnected;
     _appId = appId;
-    _certificateManager = [[_SDLCertificateManager alloc] initWithCertificateServerURL:CertQAURL];
+    _certificateManager = [[SDLCertificateManager alloc] initWithCertificateServerURL:CertQAURL];
 
     SSL_load_error_strings();
     ERR_load_BIO_strings();

--- a/SDLSecurityTests/SDLCertificateManagerTests.m
+++ b/SDLSecurityTests/SDLCertificateManagerTests.m
@@ -8,7 +8,7 @@
 
 #import <XCTest/XCTest.h>
 
-#import "_SDLCertificateManager.h"
+#import "SDLCertificateManager.h"
 
 
 static NSString *const TestAppId = @"000000000";
@@ -16,7 +16,7 @@ static NSString *const TestAppId = @"000000000";
 
 @interface SDLCertificateManagerTests : XCTestCase
 
-@property (strong, nonatomic) _SDLCertificateManager *certManager;
+@property (strong, nonatomic) SDLCertificateManager *certManager;
 
 @end
 
@@ -27,7 +27,7 @@ static NSString *const TestAppId = @"000000000";
     [super setUp];
     // Put setup code here. This method is called before the invocation of each test method in the class.
     
-    self.certManager = [[_SDLCertificateManager alloc] initWithCertificateServerURL:@"testURL"];
+    self.certManager = [[SDLCertificateManager alloc] initWithCertificateServerURL:@"testURL"];
 }
 
 - (void)tearDown {

--- a/SDLSecurityTests/SDLTLSEngineTests.m
+++ b/SDLSecurityTests/SDLTLSEngineTests.m
@@ -8,14 +8,14 @@
 
 #import <XCTest/XCTest.h>
 
-#import "_SDLTLSEngine.h"
+#import "SDLTLSEngine.h"
 
 static NSString *const TestAppId = @"584421907";
 
 
 @interface SDLTLSEngineTests : XCTestCase
 
-@property (strong, nonatomic) _SDLTLSEngine *tlsEngine;
+@property (strong, nonatomic) SDLTLSEngine *tlsEngine;
 
 @end
 
@@ -31,7 +31,7 @@ static NSString *const TestAppId = @"584421907";
     [super setUp];
     // Put setup code here. This method is called before the invocation of each test method in the class.
     
-    self.tlsEngine = [[_SDLTLSEngine alloc] initWithAppId:TestAppId];
+    self.tlsEngine = [[SDLTLSEngine alloc] initWithAppId:TestAppId];
 }
 
 - (void)tearDown {


### PR DESCRIPTION
Fixes #29 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
* Smoke tests
* Added test cases

### Summary
* Moved setting of `availableMakes` to `SDLPrivateSecurityConstants`
* Renamed two private classes to remove underscore:  `SDLTLSEngine` and `SDLCertificateManager`

### Changelog
##### Enhancements
* Consolidate setting of private constants in `SDLPrivateSecurityConstants`.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
