### PR TITLE
Configured certificate URL for release and debug configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This library can be used to encrypt [SDL services](https://github.com/smartdevic
 The following customizations must be made by the OEM in order for the library to work with their proprietary version of SDL Core:
 
 ### Certificate URL
-The `CertQAURL` URL in the **SDLPrivateSecurityConstants.m** file should be updated to point to a database that will return certificate data for a specific SDL `appID`. The certificate data will be stored on disk as a `.pfx` file so it can persist between app sessions. If the certificate has expired, the library will automatically try to download a new certificate. 
+The `CertificateURL` in the **SDLPrivateSecurityConstants.m** file should be updated to point to a database that will return certificate data for a specific SDL `appID`. The certificate data will be stored on disk as a `.pfx` file so it can persist between app sessions. If the certificate has expired, the library will automatically try to download a new certificate. 
 
 Depending on the response you return for the certificate request, you may need to update how the certificate is extracted from the JSON object in **SDLCertificateManager.m**. Currently the certificate manager is set up to handle parsing this JSON format:
 ```

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This library can be used to encrypt [SDL services](https://github.com/smartdevic
 The following customizations must be made by the OEM in order for the library to work with their proprietary version of SDL Core:
 
 ### Certificate URL
-The `CertificateURL` in the **SDLPrivateSecurityConstants.m** file should be updated to point to a database that will return certificate data for a specific SDL `appID`. The certificate data will be stored on disk as a `.pfx` file so it can persist between app sessions. If the certificate has expired, the library will automatically try to download a new certificate. 
+The `CertificateURL` in the **SDLPrivateSecurityConstants.m** file should be updated to point to an API URL that will return certificate data for a specific SDL `appID`. The certificate data will be stored on disk as a `.pfx` file so it can persist between app sessions. If the certificate has expired, the library will automatically try to download a new certificate. 
 
 Depending on the response you return for the certificate request, you may need to update how the certificate is extracted from the JSON object in **SDLCertificateManager.m**. Currently the certificate manager is set up to handle parsing this JSON format:
 ```

--- a/SDLSecurity/SDLPrivateSecurityConstants.h
+++ b/SDLSecurity/SDLPrivateSecurityConstants.h
@@ -11,12 +11,6 @@
 /// The development URL from which to download the PFX file data.
 extern NSString * _Nonnull const CertificateURL;
 
-/// The quality assurance URL from which to download the PFX file data.
-extern NSString * _Nonnull const CertQAURL;
-
-/// The production URL from which to download the PFX file data.
-extern NSString * _Nonnull const CertProdURL;
-
 /// The issuer of the PFX file.
 extern NSString * _Nonnull const SDLTLSIssuer;
 

--- a/SDLSecurity/SDLPrivateSecurityConstants.h
+++ b/SDLSecurity/SDLPrivateSecurityConstants.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
-/// The development URL from which to download the PFX file data.
+/// The URL from which to download the PFX file data.
 extern NSString * _Nonnull const CertificateURL;
 
 /// The issuer of the PFX file.

--- a/SDLSecurity/SDLPrivateSecurityConstants.h
+++ b/SDLSecurity/SDLPrivateSecurityConstants.h
@@ -8,9 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
-extern NSString *const CertDevURL;
-extern NSString *const CertQAURL;
-extern NSString *const CertProdURL;
+extern NSString *const CertificateURL;
 extern NSString *const VendorName;
 extern NSString *const SDLTLSIssuer;
 extern const char *SDLTLSCertPassword;

--- a/SDLSecurity/SDLPrivateSecurityConstants.m
+++ b/SDLSecurity/SDLPrivateSecurityConstants.m
@@ -11,10 +11,10 @@
 /// Sets the certificate url based on whether the build configuration is RELEASE or DEBUG
 #if DEBUG
 /// Certificate URL for debugging
-NSString * _Nonnull const CertDevURL = @"https://www.debugURL.com";
+NSString * _Nonnull const CertificateURL = @"https://www.debugURL.com";
 #else
 /// Certificate URL for release
-NSString * _Nonnull const CertDevURL = @"https://www.productionURL.com";
+NSString * _Nonnull const CertificateURL = @"https://www.productionURL.com";
 #endif
 
 const char *SDLTLSCertPassword = "SDLTLSCertPassword";

--- a/SDLSecurity/SDLPrivateSecurityConstants.m
+++ b/SDLSecurity/SDLPrivateSecurityConstants.m
@@ -8,9 +8,15 @@
 
 #import "SDLPrivateSecurityConstants.h"
 
-NSString *const CertDevURL = @"http://www.google.com";
-NSString *const CertQAURL = @"http://www.google.com";
-NSString *const CertProdURL = @"http://www.google.com";
+/// Sets the certificate url based on whether the build configuration is RELEASE or DEBUG
+#if DEBUG
+/// Certificate URL for debugging
+NSString *const CertificateURL = @"https://www.debugURL.com";
+#else
+/// Certificate URL for release
+NSString *const CertificateURL = @"https://www.productionURL.com";
+#endif
+
 NSString *const VendorName = @"SDL";
 NSString *const SDLTLSIssuer = @"SDLTLSIssuer";
 const char *SDLTLSCertPassword = "SDLTLSCertPassword";

--- a/SDLSecurity/SDLPrivateSecurityConstants.m
+++ b/SDLSecurity/SDLPrivateSecurityConstants.m
@@ -17,7 +17,9 @@ NSString * _Nonnull const CertificateURL = @"https://www.debugURL.com";
 NSString * _Nonnull const CertificateURL = @"https://www.productionURL.com";
 #endif
 
-const char *SDLTLSCertPassword = "SDLTLSCertPassword";
+NSString * _Nonnull const SDLTLSIssuer = @"SDLTLSIssuer";
+const char * _Nonnull SDLTLSCertPassword = "SDLTLSCertPassword";
+NSString * _Nonnull const VendorName = @"SDL";
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/SDLSecurity/SDLPrivateSecurityConstants.m
+++ b/SDLSecurity/SDLPrivateSecurityConstants.m
@@ -8,7 +8,7 @@
 
 #import "SDLPrivateSecurityConstants.h"
 
-/// Sets the certificate url based on whether the build configuration is RELEASE or DEBUG
+/// Sets the certificate url based on whether the build configuration for this library is RELEASE or DEBUG
 #if DEBUG
 /// Certificate URL for debugging
 NSString * _Nonnull const CertificateURL = @"https://www.debugURL.com";

--- a/SDLSecurity/SDLTLSEngine.m
+++ b/SDLSecurity/SDLTLSEngine.m
@@ -59,7 +59,7 @@ static const int SDLTLSReadBufferSize = 4096;
     
     _state = SDLTLSEngineStateDisconnected;
     _appId = appId;
-    _certificateManager = [[SDLCertificateManager alloc] initWithCertificateServerURL:CertQAURL];
+    _certificateManager = [[SDLCertificateManager alloc] initWithCertificateServerURL:CertificateURL];
 
     SSL_load_error_strings();
     ERR_load_BIO_strings();

--- a/SDLSecurity/SDLTLSEngine.m
+++ b/SDLSecurity/SDLTLSEngine.m
@@ -341,7 +341,6 @@ static NSDate *sdlsec_certificateGetExpiryDate(X509 *certificateX509) {
         }
     }
 
-    SDLSecurityLogD(@"Certificate expiration date: %@", expiryDate);
     return expiryDate;
 }
 


### PR DESCRIPTION
Fixes #24 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Smoke tests performed

### Summary
* Replaced three certificate URLs with one URL that can be configured based on whether the security library's build configuration is release or debug. 

### Changelog
##### Enhancements
* Configured the certificate URL so separate URLs can be set based on whether the build configuration is release or debug. 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
