### PR TITLE
Fixed Creating a Dynamic Framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Once the security library has been configured by the OEM, it is used to generate
     SDLEncryptionConfiguration *encryptionConfig = [[SDLEncryptionConfiguration alloc] initWithSecurityManagers:@[SDLSecurityManager.self] delegate:self];
     ```
 
-### Dynamic Security Library Framework
+## Dynamic Security Library Framework
 For convenience when debugging (it's less secure than a static framework, which can more easily be obfuscated), a dynamic framework can be easily built and dropped into a SDL iOS app.
 
 ### Generating the Dynamic Security Library Framework

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ For convenience when debugging (it's less secure than a static framework, which 
 ## Updating the OpenSSL Dependency
 We have included a build of the OpenSSL library so that the security library can work out of the box with a few minor customizations. However, this example does not often update the OpenSSL build and it is provided for example purposes. Production versions of this library should replace the OpenSSL dependency with an updated and trusted build. The following configurations may have to be updated:
 
-1. Make sure that the OpenSSL library builds **libcrypto.a** and **libssl.a** have been added to the **SDLSecurityStatic** target.
-1. Configure the build settings for the **SDLSecurityStatic** target.
+1. Make sure that the OpenSSL library builds **libcrypto.a** and **libssl.a** have been added to the **SDLSecurityStatic** and the **SDLSecurity** targets.
+1. Configure the build settings for the **SDLSecurityStatic** and **SDLSecurity** targets.
     * In **Build Settings > Library Search Paths** include the path to the **libcrypto.a** and **libssl.a** static libraries.
     * In **Build Settings > Header Search Paths** include the path to the **OpenSSL** public headers.

--- a/README.md
+++ b/README.md
@@ -41,9 +41,10 @@ Once the certificate is downloaded it is stored on disk so the certificate can p
 ### Renaming the Library
 In order to use this security library with SDL, an OEM must rename this library and classes. This is because a developer who wants to support multiple OEMS will have to add a security manager from each OEM. If OEMS use the same class names then it will be impossible for the developer to include more than one security library in their application.
 
-## Generating the Static Security Library
-Once the security library has been configured by the OEM, it is used to generate a static library that developers add to their SDL iOS apps. The static library, **libSDLSecurityStatic.a**, can easily be built in Xcode using the **SDLSecurityStatic** target:
+## Static Security Library
+Once the security library has been configured by the OEM, it is used to generate a static library that developers add to their SDL iOS apps. The static library, **libSDLSecurityStatic.a**, can easily be built in Xcode using the **SDLSecurityStatic** target. 
 
+### Generating the Static Security Library
 1. In the scheme menu of Xcode, set the active scheme to **SDLSecurityStatic**.
 1. Build and run the **SDLSecurityStatic** scheme (**Product > Build For > Running**). 
 1. In the project navigator you will find the **libSDLSecurityStatic.a** build under **SDLSecurity > Products**.
@@ -53,20 +54,46 @@ Once the security library has been configured by the OEM, it is used to generate
     * *Debug-universal* - will work on both the iPhone and simulator
 1. There are also two header files in the **include** folder, **SDLSecurityConstants.h** and **SDLSecurityManager.h** that must be included along with **libSDLSecurityStatic.a** archive build.
     
-## Adding the Static Security Library to a SDL App
+### Adding the Static Security Library to a SDL App
 1. In Xcode, drag and drop the following 3 files into your project: **libSDLSecurityStatic.a**, **SDLSecurityConstants.h** and **SDLSecurityManager.h** (or their equivalents after OEM naming modifications are made). Make sure **libSDLSecurityStatic.a** has been added to the project's target membership.  
 1. Import **SDLSecurityManager.h** into the file where the the `SDLConfiguration`'s `SDLEncryptionConfiguration` or `SDLStreamingMediaConfiguration` is being set. If you have a Swift project, this will require adding a bridging header to the project.
 
-### Adding the SDLSecurityManager to a Project
-#### Swift
-```swift
-let encryptionConfig = SDLEncryptionConfiguration(securityManagers: [SDLSecurityManager.self]], delegate: nil)
-```
+    #### Swift
+    ```swift
+    let encryptionConfig = SDLEncryptionConfiguration(securityManagers: [SDLSecurityManager.self]], delegate: self)
+    ```
 
-#### Objective-C
-```objc
-SDLEncryptionConfiguration *encryptionConfig = [[SDLEncryptionConfiguration alloc] initWithSecurityManagers:@[SDLSecurityManager.self] delegate:nil];
-```
+    #### Objective-C
+    ```objc
+    SDLEncryptionConfiguration *encryptionConfig = [[SDLEncryptionConfiguration alloc] initWithSecurityManagers:@[SDLSecurityManager.self] delegate:self];
+    ```
+
+### Dynamic Security Library Framework
+For convenience when debugging, a dynamic framework can also be built and dropped into the SDL iOS app.
+
+### Generating the Dynamic Security Library Framework
+1. In the scheme menu of Xcode, set the active scheme to **SDLSecurity**.
+1. Build and run the **SDLSecurity** scheme (**Product > Build For > Running**). If you want to use the build in the simulator, you must select a simulated device as the run destination before building and running; likewise, to use on an iPhone, you must select a real device as the run destination.
+1. In the project navigator you will find the **SDLSecurity.framework** build under **SDLSecurity > Products**.
+1. Right click on the **SDLSecurity.framework** build and select **Show in Finder**. This will take you to the derived data of the project which has the framework.
+
+### Adding the Dynamic Security Library Framework to a SDL App
+1. In Xcode, drag and drop the framework into your project.   
+1. Import the `SDLSecurity` module into the file where the the `SDLConfiguration`'s `SDLEncryptionConfiguration` or `SDLStreamingMediaConfiguration` is being set.
+
+    #### Swift
+    ```swift
+    import SDLSecurity
+
+    let encryptionConfig = SDLEncryptionConfiguration(securityManagers: [SDLSecurityManager.self]], delegate: self)
+    ```
+
+    #### Objective-C
+    ```objc
+    @import SDLSecurity;
+
+    SDLEncryptionConfiguration *encryptionConfig = [[SDLEncryptionConfiguration alloc] initWithSecurityManagers:@[SDLSecurityManager.self] delegate:self];
+    ```
 
 ## Updating the OpenSSL Dependency
 We have included a build of the OpenSSL library so that the security library can work out of the box with a few minor customizations. However, this example does not often update the OpenSSL build and it is provided for example purposes. Production versions of this library should replace the OpenSSL dependency with an updated and trusted build. The following configurations may have to be updated:

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Once the security library has been configured by the OEM, it is used to generate
     ```
 
 ### Dynamic Security Library Framework
-For convenience when debugging, a dynamic framework can also be built and dropped into the SDL iOS app.
+For convenience when debugging, a dynamic framework can be easily built and dropped into a SDL iOS app.
 
 ### Generating the Dynamic Security Library Framework
 1. In the scheme menu of Xcode, set the active scheme to **SDLSecurity**.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Once the security library has been configured by the OEM, it is used to generate
     ```
 
 ### Dynamic Security Library Framework
-For convenience when debugging, a dynamic framework can be easily built and dropped into a SDL iOS app.
+For convenience when debugging (it's less secure than a static framework, which can more easily be obfuscated), a dynamic framework can be easily built and dropped into a SDL iOS app.
 
 ### Generating the Dynamic Security Library Framework
 1. In the scheme menu of Xcode, set the active scheme to **SDLSecurity**.

--- a/SDLSecurity.xcodeproj/project.pbxproj
+++ b/SDLSecurity.xcodeproj/project.pbxproj
@@ -24,7 +24,7 @@
 		5D8468301C86256D00592787 /* SDLPrivateSecurityConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D84682C1C86256D00592787 /* SDLPrivateSecurityConstants.m */; };
 		5DAECE79232BF3890041A7E9 /* SDLSecurityLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D4DC2DF23214D00003A69B0 /* SDLSecurityLogger.h */; };
 		5DAECE7A232BF38C0041A7E9 /* SDLSecurityLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D4DC2E023214D00003A69B0 /* SDLSecurityLogger.m */; };
-		5DC412F41C62426F0062E6F9 /* SDLSecurityType.h in Headers */ = {isa = PBXBuildFile; fileRef = 5DC412F31C62426F0062E6F9 /* SDLSecurityType.h */; };
+		5DC412F41C62426F0062E6F9 /* SDLSecurityType.h in Headers */ = {isa = PBXBuildFile; fileRef = 5DC412F31C62426F0062E6F9 /* SDLSecurityType.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5DF04F361C629116001B9986 /* SDLSecurityType.h in Headers */ = {isa = PBXBuildFile; fileRef = 5DC412F31C62426F0062E6F9 /* SDLSecurityType.h */; };
 		5DF916FB1C5A6C69009C7B55 /* SDLSecurityManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D40CA981C51215200E6F987 /* SDLSecurityManager.m */; };
 		5DF916FF1C5A6C94009C7B55 /* SDLSecurityManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D40CA971C51215200E6F987 /* SDLSecurityManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -313,6 +313,7 @@
 				5D40CA981C51215200E6F987 /* SDLSecurityManager.m */,
 				5DF917101C5AA368009C7B55 /* SDLSecurityConstants.h */,
 				5DF917111C5AA368009C7B55 /* SDLSecurityConstants.m */,
+				88136021236A1F03000F64DD /* Protocol */,
 			);
 			name = Public;
 			sourceTree = "<group>";
@@ -323,13 +324,20 @@
 				5D81600823214B9A001EAAB2 /* Logger */,
 				5D84682B1C86256D00592787 /* SDLPrivateSecurityConstants.h */,
 				5D84682C1C86256D00592787 /* SDLPrivateSecurityConstants.m */,
-				5DC412F31C62426F0062E6F9 /* SDLSecurityType.h */,
 				5DF917071C5A6F1C009C7B55 /* SDLTLSEngine.h */,
 				5DF917081C5A6F1C009C7B55 /* SDLTLSEngine.m */,
 				5D5E27851C848A1900495F0B /* SDLCertificateManager.h */,
 				5D5E27861C848A1900495F0B /* SDLCertificateManager.m */,
 			);
 			name = Private;
+			sourceTree = "<group>";
+		};
+		88136021236A1F03000F64DD /* Protocol */ = {
+			isa = PBXGroup;
+			children = (
+				5DC412F31C62426F0062E6F9 /* SDLSecurityType.h */,
+			);
+			name = Protocol;
 			sourceTree = "<group>";
 		};
 		8842509B230D9C0000F83FD7 /* Resources */ = {

--- a/SDLSecurity/SDLCertificateManager.m
+++ b/SDLSecurity/SDLCertificateManager.m
@@ -12,6 +12,7 @@
 #import "SDLSecurityConstants.h"
 #import "SDLSecurityLoggerMacros.h"
 
+NS_ASSUME_NONNULL_BEGIN
 
 @interface SDLCertificateManager ()
 
@@ -139,3 +140,5 @@
 }
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/SDLSecurity/SDLSecurity.h
+++ b/SDLSecurity/SDLSecurity.h
@@ -5,6 +5,7 @@
 //  Created by Joel Fischer on 1/21/16.
 //  Copyright © 2016 livio. All rights reserved.
 //
+//  Umbrella header for the SDLSecurity module. This file contains all the public header files for the project.
 
 #import <UIKit/UIKit.h>
 
@@ -14,6 +15,7 @@ FOUNDATION_EXPORT double SDLSecurityVersionNumber;
 //! Project version string for SDLSecurity.
 FOUNDATION_EXPORT const unsigned char SDLSecurityVersionString[];
 
-#import <SDLSecurity/SDLTLSSecurityManager.h>
-#import <SDLSecurity/SDLSecurityType.h>
+// All public headers of the SDLSecurity framework
 #import <SDLSecurity/SDLSecurityConstants.h>
+#import <SDLSecurity/SDLSecurityManager.h>
+#import <SDLSecurity/SDLSecurityType.h> // Since this protocol is exposed in `SDLSecurityManager.h` it must also be a public header


### PR DESCRIPTION
Fixes #40 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Smoke tests performed using the module in Swift and Obj-C apps.

### Summary
* The umbrella header for the module now contains all the public header files.
* The `SDLSecurityType.h` header file was made public for the **SDLSecurity** target. Otherwise the module will not build in a Swift project due to the missing `SDLSecurityType.h`.

### Changelog
##### Enhancements
* The security library can now generate a working dynamic framework.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
