### PR TITLE
Data is now read from the SSL server until no more data is available

### DIFF
--- a/SDLSecurity/SDLTLSEngine.h
+++ b/SDLSecurity/SDLTLSEngine.h
@@ -29,7 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param error The error is set if initialization failed
 - (BOOL)initializeTLSWithCertificateData:(NSData *)data error:(NSError **)error;
 
-/// Closes the the current DTLS/SSL connection.
+/// Closes the current DTLS/SSL connection.
 - (void)shutdownTLS;
 
 /// Generates handshake data using client data.

--- a/SDLSecurity/SDLTLSEngine.m
+++ b/SDLSecurity/SDLTLSEngine.m
@@ -493,7 +493,7 @@ static NSDate *sdlsec_certificateGetExpiryDate(X509 *certificateX509) {
 
 #pragma mark - Errors
 
-/// Examines the result code returned when attempting to read or write data from the server and returns a human readable version of the result code. If an error occured, an error is returned; if successful no error is returned.
+/// Examines the result code returned when attempting to read or write data from the server and returns a human readable version of the result code. If an error occured, an error is returned; if successful, no error is returned.
 /// @param ssl The DTLS/SSL connection
 /// @param value The value returned by the read or write action
 /// @param length The length of the data read or written

--- a/SDLSecurity/SDLTLSEngine.m
+++ b/SDLSecurity/SDLTLSEngine.m
@@ -473,13 +473,13 @@ static NSDate *sdlsec_certificateGetExpiryDate(X509 *certificateX509) {
 /// Retrieves the encrypted data from the OpenSSL server.
 /// @param error The error will be set if the data can not be retrieved successfully
 - (nullable NSData *)sdlsec_ReadEncryptedDataFromSSLServerWithError:(NSError * __autoreleasing*)error {
-    NSMutableData *returnData = [NSMutableData data];
+    NSMutableData *encryptedData = [NSMutableData data];
     int length = SDLTLSReadBufferSize;
     void *buffer = malloc(SDLTLSReadBufferSize);
     int bufferLength = 0;
 
     while ((bufferLength = BIO_read(writeBIO, buffer, length)) >= 0) {
-        [returnData appendBytes:buffer length:bufferLength];
+        [encryptedData appendBytes:buffer length:bufferLength];
 
         SDLTLSErrorCode errorCode = [self.class sdlsec_errorCodeFromSSL:sslConnection value:bufferLength length:length isWrite:NO];
         if ((errorCode != SDLTLSErrorCodeNone) && (*error != nil)) {
@@ -487,7 +487,7 @@ static NSDate *sdlsec_certificateGetExpiryDate(X509 *certificateX509) {
         }
     }
 
-    return returnData;
+    return encryptedData;
 }
 
 

--- a/SDLSecurity/SDLTLSEngine.m
+++ b/SDLSecurity/SDLTLSEngine.m
@@ -383,7 +383,7 @@ static NSDate *sdlsec_certificateGetExpiryDate(X509 *certificateX509) {
         return nil;
     }
     
-    [self sdlsec_writeToSSLServerUnencryptedData:decryptedData withError:error];
+    [self sdlsec_writeToSSLServerWithUnencryptedData:decryptedData withError:error];
     if (*error != nil) {
         return nil;
     }
@@ -421,7 +421,7 @@ static NSDate *sdlsec_certificateGetExpiryDate(X509 *certificateX509) {
 /// Writes the unencrypted data to the OpenSSL server so it can be encrypted and returns the number of bytes successfully written.
 /// @param data The unencrypted data
 /// @param error The error will be set if the data can not be written successfully
-- (int)sdlsec_writeToSSLServerUnencryptedData:(NSData *)data withError:(NSError * __autoreleasing*)error {
+- (int)sdlsec_writeToSSLServerWithUnencryptedData:(NSData *)data withError:(NSError * __autoreleasing*)error {
     int length = (int)data.length;
     void *buffer = (void *)data.bytes;
     int retVal = SSL_write(sslConnection, buffer, length);


### PR DESCRIPTION
Fixes #41 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Smoke tests performed.

### Summary
Reading data from the SSL server is now done in a while loop to make sure all data is read before returning.

### Changelog
##### Enhancements
* Data is now read from the SSL server until no more data is available. 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
