### PR TITLE
Certificate manager now fails gracefully if response is not formatted as expected

### DIFF
--- a/SDLSecurity/SDLCertificateManager.m
+++ b/SDLSecurity/SDLCertificateManager.m
@@ -66,12 +66,13 @@ NS_ASSUME_NONNULL_BEGIN
         }
 
         NSString *certificateKey = @"data.certificate";
-        if ([jsonDictionary valueForKeyPath:certificateKey] == nil) {
+        NSData *certificateBase64EncodedData = [jsonDictionary valueForKeyPath:certificateKey];
+        if (certificateBase64EncodedData == nil) {
             SDLSecurityLogE(@"Error parsing the network request data for the certificate");
             return completionHandler(NO, [NSError errorWithDomain:SDLSecurityErrorDomain code:SDLTLSErrorCodeNoCertificate userInfo:@{NSLocalizedDescriptionKey: @"Network request did not return certificate data in the expected JSON format"}]);
         }
 
-        NSData *certificateData = [[NSData alloc] initWithBase64EncodedData:[jsonDictionary valueForKeyPath:certificateKey] options:0];
+        NSData *certificateData = [[NSData alloc] initWithBase64EncodedData:certificateBase64EncodedData options:0];
         if (certificateData.length == 0) {
             SDLSecurityLogE(@"Certificate is invalid");
             return completionHandler(NO, [NSError errorWithDomain:SDLSecurityErrorDomain code:SDLTLSErrorCodeCertificateInvalid userInfo:@{NSLocalizedDescriptionKey: @"Certificate is invalid"}]);

--- a/SDLSecurity/SDLCertificateManager.m
+++ b/SDLSecurity/SDLCertificateManager.m
@@ -66,7 +66,7 @@ NS_ASSUME_NONNULL_BEGIN
         }
 
         NSString *certificateKey = @"data.certificate";
-        if (![jsonDictionary valueForKeyPath:certificateKey]) {
+        if ([jsonDictionary valueForKeyPath:certificateKey] == nil) {
             SDLSecurityLogE(@"Error parsing the network request data for the certificate");
             return completionHandler(NO, [NSError errorWithDomain:SDLSecurityErrorDomain code:SDLTLSErrorCodeNoCertificate userInfo:@{NSLocalizedDescriptionKey: @"Network request did not return certificate data in the expected JSON format"}]);
         }

--- a/SDLSecurity/SDLCertificateManager.m
+++ b/SDLSecurity/SDLCertificateManager.m
@@ -62,10 +62,16 @@ NS_ASSUME_NONNULL_BEGIN
 
         if (jsonError != nil || jsonDictionary == nil) {
             SDLSecurityLogE(@"Error parsing network request data");
-            return completionHandler(NO, [NSError errorWithDomain:SDLSecurityErrorDomain code:SDLTLSErrorCodeNoCertificate userInfo:@{NSLocalizedDescriptionKey: @"Network request did not return a certificate"}]);
+            return completionHandler(NO, [NSError errorWithDomain:SDLSecurityErrorDomain code:SDLTLSErrorCodeNoCertificate userInfo:@{NSLocalizedDescriptionKey: @"Network request did not return data in the expected format"}]);
         }
 
-        NSData *certificateData = [[NSData alloc] initWithBase64EncodedData:[jsonDictionary valueForKeyPath:@"data.certificate"] options:0];
+        NSString *certificateKey = @"data.certificate";
+        if (![jsonDictionary valueForKeyPath:certificateKey]) {
+            SDLSecurityLogE(@"Error parsing the network request data for the certificate");
+            return completionHandler(NO, [NSError errorWithDomain:SDLSecurityErrorDomain code:SDLTLSErrorCodeNoCertificate userInfo:@{NSLocalizedDescriptionKey: @"Network request did not return certificate data in the expected JSON format"}]);
+        }
+
+        NSData *certificateData = [[NSData alloc] initWithBase64EncodedData:[jsonDictionary valueForKeyPath:certificateKey] options:0];
         if (certificateData.length == 0) {
             SDLSecurityLogE(@"Certificate is invalid");
             return completionHandler(NO, [NSError errorWithDomain:SDLSecurityErrorDomain code:SDLTLSErrorCodeCertificateInvalid userInfo:@{NSLocalizedDescriptionKey: @"Certificate is invalid"}]);


### PR DESCRIPTION
Fixes #47 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Smoke tests performed. 

Make sure when testing to clear the device's cache so a new certificate is downloaded.

### Summary
When the request for certificate data returns JSON formatted differently from the expected format, the library now returns an error instead of crashing.

### Changelog
##### Bug Fixes
* Fixed the library crashing if the network request returns a JSON formatted message different from the one it expects.

### Tasks Remaining:
- [x] Test with SDL Core

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
