### PR TITLE
Change ASL Log to OSLog

### DIFF
--- a/SDLSecurity.xcodeproj/project.pbxproj
+++ b/SDLSecurity.xcodeproj/project.pbxproj
@@ -621,7 +621,7 @@
 		5D40CA741C511C7200E6F987 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1030;
+				LastUpgradeCheck = 1250;
 				ORGANIZATIONNAME = livio;
 				TargetAttributes = {
 					5D40CA7C1C511C7200E6F987 = {

--- a/SDLSecurity.xcodeproj/xcshareddata/xcschemes/SDLSecurityStatic.xcscheme
+++ b/SDLSecurity.xcodeproj/xcshareddata/xcschemes/SDLSecurityStatic.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1030"
+   LastUpgradeVersion = "1250"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -29,8 +29,6 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -51,8 +49,6 @@
             ReferencedContainer = "container:SDLSecurity.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/SDLSecurity/SDLSecurityLogger.m
+++ b/SDLSecurity/SDLSecurityLogger.m
@@ -8,11 +8,17 @@
 
 #import "SDLSecurityLogger.h"
 
-#import <asl.h>
+#import <OSLog/OSLog.h>
 
 #import "SDLSecurityManager.h"
 
 NS_ASSUME_NONNULL_BEGIN
+
+@interface SDLSecurityLogger ()
+
+@property (strong, nonatomic) os_log_t logClient;
+
+@end
 
 @implementation SDLSecurityLogger
 
@@ -30,6 +36,8 @@ NS_ASSUME_NONNULL_BEGIN
     self = [super init];
     if (!self) { return nil; }
 
+    self.logClient = os_log_create("com.sdl.log", "Security");
+
     return self;
 }
 
@@ -42,9 +50,17 @@ NS_ASSUME_NONNULL_BEGIN
     NSString *logString = [NSString stringWithFormat:@"%@ %@ %@ (SDL)SecurityLibrary (%@) – %@\n", [self.class.dateFormatter stringFromDate:timestamp], [self sdl_logCharacterForLevel:level], [self sdl_logNameForLevel:level], [SDLSecurityManager availableMakes], formatMessage];
 
     const char *charLog = [logString UTF8String];
-    int result = asl_log_message(ASL_LEVEL_ERR, "%s", charLog);
-    if (result != 0) {
-        NSLog(@"Error logging to ASL log, logging to NSLog instead:\n%@", logString);
+    os_log_with_type(self.logClient, [self oslogLevelForLogLevel:level], logString);
+}
+
+- (os_log_type_t)oslogLevelForLogLevel:(LoggerLevel)level {
+    switch (level) {
+        case LoggerLevelDebug: return OS_LOG_TYPE_INFO;
+        case LoggerLevelWarning: return OS_LOG_TYPE_ERROR;
+        case LoggerLevelError: return OS_LOG_TYPE_FAULT;
+        default:
+            NSAssert(NO, @"The OFF and DEFAULT log levels are not valid to log with.");
+            return OS_LOG_TYPE_DEFAULT;
     }
 }
 

--- a/SDLSecurity/SDLSecurityLogger.m
+++ b/SDLSecurity/SDLSecurityLogger.m
@@ -49,8 +49,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     NSString *logString = [NSString stringWithFormat:@"%@ %@ %@ (SDL)SecurityLibrary (%@) – %@\n", [self.class.dateFormatter stringFromDate:timestamp], [self sdl_logCharacterForLevel:level], [self sdl_logNameForLevel:level], [SDLSecurityManager availableMakes], formatMessage];
 
-    const char *charLog = [logString UTF8String];
-    os_log_with_type(self.logClient, [self oslogLevelForLogLevel:level], logString);
+    os_log_with_type(self.logClient, [self oslogLevelForLogLevel:level], "%{public}@", logString);
 }
 
 - (os_log_type_t)oslogLevelForLogLevel:(LoggerLevel)level {


### PR DESCRIPTION
Fixes #59 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Tested against Core v7.1.1

### Summary
Removed ASL Logging because its deprecated. OSLog is the new way to do what ASL logging did.

### Changelog
##### Enhancements
* Use OSLog instead of ASL logging

### Tasks Remaining:
n/a

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
